### PR TITLE
Add cache header to static assets

### DIFF
--- a/serverConfig.js
+++ b/serverConfig.js
@@ -44,7 +44,9 @@ app.set('view engine', 'ejs');
 app.set('views', INDEX_PATH);
 
 // Assign the proper path where the application's dist files are located.
-app.use(express.static(DIST_PATH));
+app.use(express.static(DIST_PATH, {
+  maxage: '5m'
+}));
 
 // Set logger parameters
 const logger = getLogger({


### PR DESCRIPTION
I'm not sure what happened... as I think I see some (old) previous work in ACCT-190 and ACCT-198 about adding cache headers to our static assets didn't get merged. I suspect maybe this didn't get deployed because of the Bamboo building issues we were having in the past.

Right now, we re-load the static header JS and CSS on _every_ page load. This is obviously not efficient. This PR adds a conservative 5 minute `Cache-Control` header (as per https://expressjs.com/en/resources/middleware/serve-static.html).

Does anyone see any potential issues with this?