### PR TITLE
Correct development branch on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ deploy:
   secret_access_key: "$AWS_SECRET_ACCESS_KEY_DEVELOPMENT"
   region: us-east-1
   app: nypl-header-app
-  env: nypl-header-dev
+  env: nypl-header-development
   bucket_name: elasticbeanstalk-us-east-1-224280085904
-  bucket_path: nypl-header-dev
+  bucket_path: nypl-header-development
   on:
     repo: NYPL/nypl-dgx-react-header
     branch: development


### PR DESCRIPTION
Brett has changed the CNAME for `dev-header.nypl.org` to point to the new Elastic Beanstalk instance `nypl-header-development.us-east-1.elasticbeanstalk.com` on `nypl-sandbox`, hence the changes reflect on Travis configuration. Thank you!