### PR TITLE
Passing the skipnav config to the static header markup endpoint if th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ Locations, Staff Profiles, and Research Divisions all pull in the Header through
 There are configurations that can be passed into the header script to enable/configure a few features.
 
 * `urls` - The accepted values are `relative`/`absolute` and `relative` is the default. This outputs the main navigation links as either relative to the app or absolute. For apps that will not live on a `nypl.org/...` path, it's best to pass `urls=absolute` into the configuration. Otherwise, the navigation will render links that will be relative to the app and that may not exist.
-* `skipNav` - The id of the `<main>` element on the app where the Header is being imported.
+* `skipNav` - The id of the `<main>` element on the app where the Header is being imported. If this configuration is being enabled, make sure to also add a `tabindex` attribute of `-1` to the main element. This will allow the Header to programmatically focus on the main content.
+
+```HTML
+<main id="main-content" tabindex="-1">
+  <!-- app goes here -->
+</main>
+```
 
 ### Drupal Import
 We call this the Drupal import way of rendering the Header because it's the only site that imports the Header in this following way. This app has a `/header-markup` endpoint that can be used to get _only_ the HTML markup for the header. Any app can use that markup as they wish, but it won't be interactive or styled unless they import the corresponding CSS and JS files as well.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Locations, Staff Profiles, and Research Divisions all pull in the Header through
 
 There are configurations that can be passed into the header script to enable/configure a few features.
 
-* `urls` - The accepted values are `relative`/`absolute` and `relative` is the default. This outputs the main navigation links as either relative to the app or absolute. For apps that will not live on a `nypl.org/...` path, it's best to pass `urls=absolute` into the configuration. Otherwise, the navigation will render links that will be relative to the app and that may not exist.
+* `urls` - The accepted values are `relative`/`absolute`, with `relative` as the default. This outputs the main navigation links as either relative to the app or absolute. For apps that will not live on an `nypl.org/...` path, it's best to pass `urls=absolute` into the configuration. Otherwise, the navigation will render links relative to the app which may not exist.
 * `skipNav` - The id of the `<main>` element on the app where the Header is being imported. If this configuration is being enabled, make sure to also add a `tabindex` attribute of `-1` to the main element. This will allow the Header to programmatically focus on the main content.
 
 ```HTML
@@ -53,12 +53,12 @@ There are configurations that can be passed into the header script to enable/con
 ```
 
 ### Drupal Import
-We call this the Drupal import way of rendering the Header because it's the only site that imports the Header in this following way. This app has a `/header-markup` endpoint that can be used to get _only_ the HTML markup for the header. Any app can use that markup as they wish, but it won't be interactive or styled unless they import the corresponding CSS and JS files as well.
+We call this the Drupal import way of rendering the Header because it's the only site that imports the Header in this way. This app has a `/header-markup` endpoint that can be used to get _only_ the HTML markup for the header. Any app can use that markup as they wish, but it won't be interactive or styled unless they import the corresponding CSS and JS files as well.
 
 * JS - https://header.nypl.org/dgx-header.min.js
 * CSS - https://header.nypl.org/styles.css
 
-*NOTE* - It is important to know that if you follow this approach, you are free but responsible to import all the files together and render them correctly along with your own app's production build.
+*NOTE* - It is important to know that if you follow this approach, you are free to but responsible for importing all the files together and rendering them correctly along with your own app's production build.
 
 ## Installation
 Install all NPM dependencies listed under `package.json`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,42 @@ Pass in the following environment variables:
 
 - `NODE_ENV`: Sets up the app to be minified using `production`. Otherwise, it will default to development mode in Webpack.
 
+## Dynamic Embedded Header Usage
+The Header is a standalone application that can potentially be picked up by many different applications. Currently, Locations, Staff Profiles, Research Divisions, Old Drupal, and New Drupal use the production build of this repo to import the Header into their application. There are differences in how the Header is pulled in and configurations for the nav links and skip navigation.
+
+### Embeddable Script
+Locations, Staff Profiles, and Research Divisions all pull in the Header through an embeddable standalone script tag that should be used in the `<body>` element of the main HTML file (or any other HTML files in the app). Since the Header loads dynamically, the script is surrounded by optional HTML markup and styles so that the top part of the page doesn't jump and cause a flash. It is suggested that the Header be imported as a whole with the following markup:
+
+```HTML
+<!-- Header -->
+<div id="Header-Placeholder">
+    <style>
+        #Header-Placeholder {
+            min-height: 70px;
+        }
+        @media screen and (min-width: 1024px) {
+            #Header-Placeholder {
+                min-height: 230px;
+            }
+        }
+    </style>
+    <script type="text/javascript" src="https://header.nypl.org/dgx-header.min.js?skipNav=main-content" async></script>
+</div>
+```
+
+There are configurations that can be passed into the header script to enable/configure a few features.
+
+* `urls` - The accepted values are `relative`/`absolute` and `relative` is the default. This outputs the main navigation links as either relative to the app or absolute. For apps that will not live on a `nypl.org/...` path, it's best to pass `urls=absolute` into the configuration. Otherwise, the navigation will render links that will be relative to the app and that may not exist.
+* `skipNav` - The id of the `<main>` element on the app where the Header is being imported.
+
+### Drupal Import
+We call this the Drupal import way of rendering the Header because it's the only site that imports the Header in this following way. This app has a `/header-markup` endpoint that can be used to get _only_ the HTML markup for the header. Any app can use that markup as they wish, but it won't be interactive or styled unless they import the corresponding CSS and JS files as well.
+
+* JS - https://header.nypl.org/dgx-header.min.js
+* CSS - https://header.nypl.org/styles.css
+
+*NOTE* - It is important to know that if you follow this approach, you are free but responsible to import all the files together and render them correctly along with your own app's production build.
+
 ## Installation
 Install all NPM dependencies listed under `package.json`
 ```sh

--- a/serverConfig.js
+++ b/serverConfig.js
@@ -68,6 +68,7 @@ app.use(initMorgan(logger));
 
 // Match all routes to render the index page.
 app.get('/', (req, res) => {
+  const iso = new Iso();
   const skipNav = req.query.skipNav || '';
 
   alt.bootstrap(JSON.stringify(res.locals.data || {}));

--- a/serverConfig.js
+++ b/serverConfig.js
@@ -92,12 +92,17 @@ app.get('/', (req, res) => {
 */
 app.get('/header-markup', (req, res) => {
   const urlType = req.query.urls || '';
+  const skipNav = req.query.skipNav || '';
 
   alt.bootstrap(JSON.stringify(res.locals.data || {}));
 
   const iso = new Iso();
   const headerApp = ReactDOMServer.renderToString(
-    <Header urlType={(urlType === 'absolute') ? 'absolute' : ''} navData={navConfig.current} />
+    <Header
+      urlType={(urlType === 'absolute') ? 'absolute' : ''}
+      navData={navConfig.current}
+      skipNav={skipNav ? { target: skipNav } : null}
+    />
   );
 
   iso.add(headerApp, alt.flush());

--- a/serverConfig.js
+++ b/serverConfig.js
@@ -68,9 +68,12 @@ app.use(initMorgan(logger));
 
 // Match all routes to render the index page.
 app.get('/', (req, res) => {
+  const skipNav = req.query.skipNav || '';
+
   alt.bootstrap(JSON.stringify(res.locals.data || {}));
-  const iso = new Iso();
-  const headerApp = ReactDOMServer.renderToString(<Header navData={navConfig.current} />);
+  const headerApp = ReactDOMServer.renderToString(
+    <Header navData={navConfig.current} skipNav={skipNav ? { target: skipNav } : null} />
+  );
   iso.add(headerApp, alt.flush());
 
   // First parameter references the ejs filename

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -172,14 +172,19 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
             // mounted on the client side, to make sure it's actually there.
             if (skipNavAdded) {
               const skipElement = document.getElementById("skip");
-              const skipAnchor = skipElement.getElementsByTagName("a")[0];
-              skipAnchor.addEventListener("keydown", (e) => {
-                const key = e.which || e.keyCode;
+              const mainElement = document.getElementById(skipNavAdded);
 
-                if (key === 13) {
-                  document.getElementById(skipNavAdded).focus();
-                }
-              });
+              if (skipElement && mainElement) {
+                const skipAnchor = skipElement.getElementsByTagName("a")[0];
+
+                skipAnchor.addEventListener("keydown", (e) => {
+                  const key = e.which || e.keyCode;
+
+                  if (key === 13) {
+                    document.getElementById(skipNavAdded).focus();
+                  }
+                });
+              }
             }
           }, 250);
         }

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -100,7 +100,6 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
           /* Since getElementsBy is an array-like structure,
           * we need to use call to iterate with forEach.
           */
-          console.log(allScriptTags);
           [].forEach.call(allScriptTags, (value, index) => {
             if (value.src.indexOf('dgx-header.min.js') !== -1) {
               scriptTag = value;

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -36,9 +36,17 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
 
       // Render Isomorphically
       Iso.bootstrap((state, meta, container) => {
+        let skipNavElem;
+        const skipNavAdded = getQueryParam(scriptTag.src, 'skipNav');
+        if (skipNavAdded) {
+          skipNavElem = {
+            target: skipNavAdded,
+          };
+        }
+
         alt.bootstrap(state);
         ReactDOM.render(
-          <Header navData={navConfig.current} />,
+          <Header navData={navConfig.current} skipNav={skipNavElem} />,
           container
         );
         isRenderedByServer = true;
@@ -53,6 +61,7 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
         let scriptTag;
         let appEnv;
         let skipNavElem;
+        let skipNavAdded;
 
         // create element to hold the single header instance.
         const htmlElement = document.createElement('div');
@@ -91,6 +100,7 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
           /* Since getElementsBy is an array-like structure,
           * we need to use call to iterate with forEach.
           */
+          console.log(allScriptTags);
           [].forEach.call(allScriptTags, (value, index) => {
             if (value.src.indexOf('dgx-header.min.js') !== -1) {
               scriptTag = value;
@@ -109,7 +119,7 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
                 urlType = urlTypeAdded;
               }
 
-              const skipNavAdded = getQueryParam(scriptTag.src, 'skipNav');
+              skipNavAdded = getQueryParam(scriptTag.src, 'skipNav');
               if (skipNavAdded) {
                 skipNavElem = {
                   target: skipNavAdded,
@@ -155,7 +165,23 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
               <Header urlType={urlType} navData={navConfig.current} skipNav={skipNavElem} />,
               htmlElement
             );
+
             console.log('nypl-dgx-header rendered via client');
+
+            // We want to programmatically focus on the skip nav id if it was
+            // passed as an argument. Do this after the component has been
+            // mounted on the client side, to make sure it's actually there.
+            if (skipNavAdded) {
+              const skipElement = document.getElementById("skip");
+              const skipAnchor = skipElement.getElementsByTagName("a")[0];
+              skipAnchor.addEventListener("keydown", (e) => {
+                const key = e.which || e.keyCode;
+
+                if (key === 13) {
+                  document.getElementById(skipNavAdded).focus();
+                }
+              });
+            }
           }, 250);
         }
       }

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -36,17 +36,9 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
 
       // Render Isomorphically
       Iso.bootstrap((state, meta, container) => {
-        let skipNavElem;
-        const skipNavAdded = getQueryParam(scriptTag.src, 'skipNav');
-        if (skipNavAdded) {
-          skipNavElem = {
-            target: skipNavAdded,
-          };
-        }
-
         alt.bootstrap(state);
         ReactDOM.render(
-          <Header navData={navConfig.current} skipNav={skipNavElem} />,
+          <Header navData={navConfig.current} />,
           container
         );
         isRenderedByServer = true;


### PR DESCRIPTION
…at url query is passed.

@gkallenberg this fixes the issue where the skipnav was not rending on old Drupal because it was not reading the query passed to the `/header-markup` endpoint.