### PR TITLE
createElement error fix

### DIFF
--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -54,7 +54,7 @@ const getQueryParam = (fullUrl = '', variableToFind) => {
         let skipNavAdded;
 
         // create element to hold the single header instance.
-        const htmlElement = document.createElement(React.createElement('div'));
+        const htmlElement = document.createElement('div');
         htmlElement.id = 'nypl-dgx-header';
 
         // Make a global object to store the instances of nyplHeader


### PR DESCRIPTION
Fix for the following error:
`Uncaught DOMException: Failed to execute 'createElement' on 'Document': The tag name provided ('[object Object]') is not a valid name.`