### PR TITLE
TGR-84: Adding deprecated note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Deprecated
+
+As of September 2024, this repo is deprecated. See the instructions in the [`nypl-header-app`](https://github.com/NYPL/nypl-header-app) repo for using the new NYPL Header and Footer.
+
+Please contact the NYPL Design System team or Remediation Team for more information.
+
+---
+
 # NYPL React Header App
 
 React NYPL Header Web Application.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 As of September 2024, this repo is deprecated. See the instructions in the [`nypl-header-app`](https://github.com/NYPL/nypl-header-app) repo for using the new NYPL Header and Footer.
 
-Please contact the NYPL Design System team or Remediation Team for more information.
-
 ---
 
 # NYPL React Header App


### PR DESCRIPTION
Resolves [TGR-84](https://newyorkpubliclibrary.atlassian.net/browse/TGR-84).

This adds a deprecated note to the repo since this codebase is no longer supported. After this is merged in, this repo will be archived.


[TGR-84]: https://newyorkpubliclibrary.atlassian.net/browse/TGR-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ